### PR TITLE
Use SPDX OR syntax in license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/AzHicham/philips-isyntax-rs"
 readme = "README.md"
 keywords = ["philips", "isyntax", "histopathology", "microscopy"]
 categories = ["science", "external-ffi-bindings"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = ["image"]


### PR DESCRIPTION
See grammar at https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields and https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/